### PR TITLE
Stuart changes

### DIFF
--- a/client/src/components/SNView.tsx
+++ b/client/src/components/SNView.tsx
@@ -168,7 +168,7 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
 
             // if note is flat, we need to bring it a line higher.
             if (accidentalType === 'auto' && getNoteAccidental(note) < 0) line++;
-            else if (accidentalType === 'flat' && getNoteAccidental(note) !== 0) line++; // handle user override
+            else if (accidentalType === 'flats' && getNoteAccidental(note) !== 0) line++; // handle user override
 
             return line;
         };
@@ -646,7 +646,7 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
             let strokeWidth = noteSymbolSize / 8;
             let crossCircleWidth = noteSymbolSize / 2 / Math.sqrt(2);
 
-            let autoNoteShape = accidentalType === 'sharp' ? sharpNoteShape : flatNoteShape;
+            let autoNoteShape = accidentalType === 'sharps' ? sharpNoteShape : flatNoteShape;
             let shape = {
                 [Accidental.Natural]: naturalNoteShape,
                 [Accidental.Flat]: accidentalType === 'auto' ? flatNoteShape : autoNoteShape,

--- a/client/src/components/SNView.tsx
+++ b/client/src/components/SNView.tsx
@@ -4,7 +4,7 @@ import {range} from '../util/Util';
 import MusicXML from 'musicxml-interfaces';
 import {parse} from '../parser/MusicXML';
 import {Note, Score, TimeSignature, KeySignature, StaffType} from '../parser/Types';
-import {colorPreferenceStyles, usePreferencesState, spacingPreferenceOption, scalePreferenceOption} from '../contexts/Preferences';
+import { colorPreferenceStyles, usePreferencesState, spacingPreferenceOption, scalePreferenceOption, lyricsFontSizeOption} from '../contexts/Preferences';
 import {useDialogState} from '../contexts/Dialog';
 import * as Dialog from '../util/Dialog';
 import {navigate} from '@reach/router';
@@ -29,7 +29,43 @@ enum Accidental {
     Sharp = 1
 }
 
-const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback = () => {}}) => {
+const keySignatureNamesArrayMajor = [
+    'Cb Major',  // -7
+    'Gb Major',  // -6
+    'Db Major',  // -5
+    'Ab Major',  // -4
+    'Eb Major',  // -3
+    'Bb Major',  // -2
+    'F Major',   // -1
+    'C Major',   //  0
+    'G Major',   //  1
+    'D Major',   //  2
+    'A Major',   //  3 
+    'E Major',   //  4
+    'B Major',   //  5
+    'F# Major',  //  6
+    'C# Major'   //  7
+];
+const keySignatureNamesArrayMinor = [
+    'g# minor', // -7
+    'eb minor', // -6
+    'bb minor', // -5
+    'f minor',  // -4
+    'c minor',  // -3
+    'g minor',  // -2
+    'd minor',  // -1
+    'a minor',  //  0
+    'e minor',  //  1
+    'b minor',  //  2
+    'f# minor', //  3 
+    'c# minor', //  4
+    'g# minor', //  5
+    'd# minor', //  6
+    'bb minor'  //  7
+]; 
+
+let creditsDisplay = ['', '', '', '', ''];
+const SNView: React.FC<Props> = ({ xml, forcedWidth, editMode = '', editCallback = () => { } }) => {
     console.log(xml);
     const ref = useRef(null! as HTMLDivElement);
     let [width, setWidth] = useState<number | undefined>(undefined);
@@ -131,6 +167,13 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
         let strokeWidth = 2;
         let tickSize = 7;
 
+        // Map lyrics font size preference to numeric values
+        let lyricsFontSizeMap: Record<lyricsFontSizeOption, number> = {
+            small: noteSymbolSize * 4 / 7,
+            medium: noteSymbolSize * 5 / 7,
+            large: noteSymbolSize * 6 / 7
+        }
+
         //vertical spacing
         let verticalPadding = 30; //top/bottom padding
         let rowPadding = verticalSpacingMap[verticalSpacing]; //space between rows
@@ -146,14 +189,11 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
         let scoreWidth = width - 2 * horizontalPadding - staffLabelSpace - octaveLabelSpace; // width of just the WYSIWYP score
         let beatWidth = scoreWidth / score.tracks[0].timeSignatures[0].beats / measuresPerRow;
 
-        // get key signature
-        let keyFifths = score.tracks[0].keySignatures[0].fifths;
-
         // let octaveGroups = [1, 1, 0, 0, 0, 1, 1]; //octaveGroups (C D E / F G A B)
         let staffLabels = preferences.clefSymbols === 'WYSIWYP' ? ['𝒯', 'ℬ'] : ['𝄞', '𝄢']; //𝄢
         let octaveLines = [
-            {color: 'red', number: true}, undefined, undefined, /* C, D, E */
-            {color: 'blue'}, undefined, undefined, undefined, /* F, G, A, B */
+            { color: 'red', number: true }, undefined, undefined, /* C, D, E */
+            { color: 'blue' }, undefined, undefined, undefined, /* F, G, A, B */
         ];
         let accidentalMap = [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0].map(x => x === 1); // C, C#, D, D#, E, ...
         let noteMap = [0, 0, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6];
@@ -174,44 +214,59 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
         };
 
         // find the title and author
-        let title = '';
+        let title = 'no title specified';
         try {
             title = xml.movementTitle;
+            console.log(title);
             title = xml.work.workTitle;
-        } catch (e) {}
+        } catch (e) { }
+        if (title === undefined) title = 'no title specified';
+        console.log(title);
 
-        let findAuthor = (): string => {
-            // 1. check identification
-            if (xml.identification !== undefined && xml.identification.creators !== undefined) {
-                for (let creator of xml.identification.creators) {
-                    if (creator.type === 'composer') {
-                        return creator.creator;
-                    }
-                }
-            }
-
-            // 2. check credits
-            let author = '';
+        let findCredits = (): number => {
+            // retrieve all credits but skip any that match the previously found title
+            console.log(creditsDisplay);
+            let creditNum = 0;
+            creditsDisplay = ['', '', '', '', ''];
             if (xml.credits !== undefined) {
                 let credits = xml.credits.filter(x => x.creditWords !== undefined && x.creditWords.length > 0).map(x => x.creditWords);
                 credits.forEach(credit => {
                     credit.forEach(words => {
-                        if (Math.abs(words.words.length - 20) < Math.abs(author.length - 20)) {
-                            author = words.words;
+                        creditsDisplay[creditNum] = words.words;
+                        //}
+                        console.log(creditNum, creditsDisplay, words, title);
+                        if (creditsDisplay[creditNum] === title) {
+                            creditsDisplay[creditNum] = '';
                         }
+                        else {
+                            creditNum = creditNum + 1;
+                        };
+                        console.log(title, creditNum, creditsDisplay);
                     });
                 });
+
             }
-            return author;
+            return creditNum;
         };
 
-        let author = findAuthor();
+        let numberOfCredits = findCredits();
+        console.log(creditsDisplay, numberOfCredits);
+
+        // get key signature
+        let keyFifths = score.tracks[0].keySignatures[0].fifths;
+        // The values for fifths range from -7 for Cb Major to +7 for C# Major.  So adjust index to names array by 7 to start at array offset 0
+        let keySignatureDisplayed = keySignatureNamesArrayMajor[keyFifths + 7] + "*";  // if no mode, default to major and indicate that with an asterisk
+        let scoreMode: any = score.tracks[0].keySignatures[0].mode;
+        if (scoreMode === 'major') keySignatureDisplayed = keySignatureNamesArrayMajor[keyFifths + 7];
+        else if (scoreMode === 'minor') keySignatureDisplayed = keySignatureNamesArrayMinor[keyFifths + 7];
+        else if (title !== 'no title specified')
+            if (title.includes(' minor') || title.includes(' Minor') || title.includes(' MINOR'))
+                keySignatureDisplayed = keySignatureNamesArrayMinor[keyFifths + 7] + "*";  // if no mode specified and "minor" is in the title, assume minor mode
 
         let minNote: Record<StaffType, number> = {
             treble: 128,
             bass: 128
         };
-
         let maxNote: Record<StaffType, number> = {
             treble: -1,
             bass: -1
@@ -389,9 +444,10 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
         let staffBreak = (i: number): JSX.Element | null => {
             // general spacing
             let textSize = noteSymbolSize * 6 / 7;
+            let lyricsFontSize = lyricsFontSizeMap[preferences.lyricsFontSize];
 
             // vertical spacing
-            let lyricsSpace = noteSymbolSize * 1.5;
+            let lyricsSpace = lyricsFontSize;
             let dynamicsSpace = noteSymbolSize * 1;
             let margin = 10;
 
@@ -462,7 +518,7 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
                     if (!dynamicsAreEmpty) y += margin + dynamicsSpace; // if there are dynamics, then we render lyrics below dynamics
 
                     lyrics.push(
-                        <text x={x} y={y} key={key++} fontSize={textSize}>
+                        <text x={x} y={y} key={key++} fontSize={lyricsFontSize}>
                             {note.attributes.lyrics}
                         </text>
                     );
@@ -644,9 +700,17 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
             let triHeight = noteSymbolSize * Math.sqrt(3) / 2;
 
             let strokeWidth = noteSymbolSize / 8;
-            let crossCircleWidth = noteSymbolSize / 2 / Math.sqrt(2);
+            
+            let autoNoteShape = 'tbd';
+            if (accidentalType === 'auto') {
+                if (keyFifths >= 0) { autoNoteShape = sharpNoteShape }
+                else { autoNoteShape = flatNoteShape }
+            }
+            else {
+                if (accidentalType === 'sharps') { autoNoteShape = sharpNoteShape }
+                else { autoNoteShape = flatNoteShape }
+            }
 
-            let autoNoteShape = accidentalType === 'sharps' ? sharpNoteShape : flatNoteShape;
             let shape = {
                 [Accidental.Natural]: naturalNoteShape,
                 [Accidental.Flat]: accidentalType === 'auto' ? flatNoteShape : autoNoteShape,
@@ -672,9 +736,6 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
                 case '●':
                     notehead = <circle cx={x} cy={y} r={noteSymbolSize / 2} fill={colorPreferenceStyles[noteSymbolColor]} />;
                     break;
-                case '◼':
-                    notehead = <rect x={x - noteSymbolSize / 2 + strokeWidth / 2} y={y - noteSymbolSize / 2 + strokeWidth / 2} width={noteSymbolSize - strokeWidth} height={noteSymbolSize - strokeWidth} fill={colorPreferenceStyles[noteSymbolColor]} />;
-                    break;
                 case '▲':
                     notehead = <polygon points={`${x},${y - triHeight / 2} ${x + noteSymbolSize / 2},${y + triHeight / 2} ${x - noteSymbolSize / 2},${y + triHeight / 2}`} fill={colorPreferenceStyles[noteSymbolColor]} />;
                     break;
@@ -684,27 +745,24 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
                 case '○':
                     notehead = <circle cx={x} cy={y} r={(noteSymbolSize - strokeWidth) / 2} strokeWidth={strokeWidth} stroke={colorPreferenceStyles[noteSymbolColor]} fill='none' />;
                     break;
-                case '☐':
-                    notehead = <rect x={x - noteSymbolSize / 2 + strokeWidth / 2} y={y - noteSymbolSize / 2 + strokeWidth / 2} width={noteSymbolSize - strokeWidth} height={noteSymbolSize - strokeWidth} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} fill='none' />;
-                    break;
                 case '△':
                     notehead = <polygon points={`${x},${y - triHeight / 2 + strokeWidth} ${x + noteSymbolSize / 2 - Math.sqrt(3) * strokeWidth / 2},${y + triHeight / 2 - strokeWidth / 2} ${x - noteSymbolSize / 2 + Math.sqrt(3) * strokeWidth / 2},${y + triHeight / 2 - strokeWidth / 2}`} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} fill='none' />;
                     break;
                 case '▽':
                     notehead = <polygon points={`${x},${y + triHeight / 2 - strokeWidth} ${x + noteSymbolSize / 2 - Math.sqrt(3) * strokeWidth / 2},${y - triHeight / 2 + strokeWidth / 2} ${x - noteSymbolSize / 2 + Math.sqrt(3) * strokeWidth / 2},${y - triHeight / 2 + strokeWidth / 2}`} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} fill='none' />;
                     break;
-                case '⊗':
+                case '#':
                     notehead = (<g>
-                        <circle cx={x} cy={y} r={(noteSymbolSize - 2) / 2} strokeWidth={strokeWidth} stroke={colorPreferenceStyles[noteSymbolColor]} fill='none' />;
-                        <line x1={x - crossCircleWidth} y1={y - crossCircleWidth} x2={x + crossCircleWidth} y2={y + crossCircleWidth} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
-                        <line x1={x - crossCircleWidth} y1={y + crossCircleWidth} x2={x + crossCircleWidth} y2={y - crossCircleWidth} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <line x1={x - (noteSymbolSize / 2) + (noteSymbolSize / 3)} y1={y - (noteSymbolSize / 2)} x2={x - (noteSymbolSize / 2) + (noteSymbolSize / 3)} y2={y + (noteSymbolSize / 2)} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <line x1={x - (noteSymbolSize / 2) + 2 * (noteSymbolSize / 3)} y1={y - (noteSymbolSize / 2)} x2={x - (noteSymbolSize / 2) + 2 * (noteSymbolSize / 3)} y2={y + (noteSymbolSize / 2)} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <line x1={x - (noteSymbolSize / 2)} y1={y - (noteSymbolSize / 2) + (noteSymbolSize / 3)} x2={x + (noteSymbolSize / 2)} y2={y - (noteSymbolSize / 2) + (noteSymbolSize / 3)} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <line x1={x - (noteSymbolSize / 2)} y1={y - (noteSymbolSize / 2) + 2 * (noteSymbolSize / 3)} x2={x + (noteSymbolSize / 2)} y2={y - (noteSymbolSize / 2) + 2 * (noteSymbolSize / 3)} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />;
                     </g>);
                     break;
-                case '⊠':
+                case 'b':
                     notehead = (<g>
-                        <rect x={x - noteSymbolSize / 2 + strokeWidth / 2} y={y - noteSymbolSize / 2 + strokeWidth / 2} width={noteSymbolSize - strokeWidth} height={noteSymbolSize - strokeWidth} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} fill='none' />
-                        <line x1={x - noteSymbolSize / 2 + strokeWidth / 2} y1={y - noteSymbolSize / 2 + strokeWidth / 2} x2={x + noteSymbolSize / 2 - strokeWidth / 2} y2={y + noteSymbolSize / 2 - strokeWidth / 2} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
-                        <line x1={x - noteSymbolSize / 2 + strokeWidth / 2} y1={y + noteSymbolSize / 2 - strokeWidth / 2} x2={x + noteSymbolSize / 2 - strokeWidth / 2} y2={y - noteSymbolSize / 2 + strokeWidth / 2} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <line x1={x - 0.6 * (noteSymbolSize / 2)} y1={y - (noteSymbolSize / 2)} x2={x - 0.6 * (noteSymbolSize / 2)} y2={y + 0.7 * (noteSymbolSize / 2)} stroke={colorPreferenceStyles[noteSymbolColor]} strokeWidth={strokeWidth} />
+                        <ellipse cx={x - (noteSymbolSize / 2) + 1.2 * (noteSymbolSize / 3)} cy={y - (noteSymbolSize / 2) + 2 * (noteSymbolSize / 3)} rx={(noteSymbolSize - strokeWidth) / 4} ry={(noteSymbolSize - strokeWidth) / 3} strokeWidth={strokeWidth} stroke={colorPreferenceStyles[noteSymbolColor]} fill='none' />
                     </g>);
                     break;
             }
@@ -717,16 +775,24 @@ const SNView: React.FC<Props> = ({xml, forcedWidth, editMode = '', editCallback 
         };
 
         let svgRows: JSX.Element[] = range(0, rowNumber).map(i => grandStaff(i));
-        let titleRowHeight = 130;
+        let titleRowHeight = 80;
+        if (title === 'no title specified') title = '';
         return (
-            <div id="snview" ref={ref} style={{width: '100%', height: 'auto', overflow: 'hidden', minWidth: '350px', userSelect: 'text', paddingTop: verticalPadding, paddingBottom: verticalPadding}}>
-                <div className={`snview-row snview-row-0`} style={{position: 'relative', height: 'auto'}}>
-                    <div style={{position: 'relative', height: 'auto'}}>
+            <div id="snview" ref={ref} style={{ width: '100%', height: 'auto', overflow: 'hidden', minWidth: '350px', userSelect: 'text', paddingTop: verticalPadding, paddingBottom: verticalPadding }}>
+                <div className={`snview-row snview-row-0`} style={{ position: 'relative', height: 'auto' }}>
+                    <div style={{ position: 'relative', height: 'auto' }}>
+
                         <svg viewBox={`0 0 ${width} ${titleRowHeight}`}>
-                            <text x={width / 2} y={10} fontSize={40} textAnchor="middle" alignmentBaseline="hanging">{title}</text>
-                            <text x={70} y={titleRowHeight - 10} fontSize={25} textAnchor="start">{score.tempo ? `${score.tempo} bpm` : null}</text>
-                            <text x={width - 70} y={titleRowHeight - 10} fontSize={25} textAnchor="end">{author}</text>
+                            <text x={width / 2} y={0} fontSize={40} textAnchor="middle" alignmentBaseline="hanging">{title}</text>
+                            <text x={70} y={20} fontSize={25} textAnchor="start">{score.tempo ? `${score.tempo} bpm` : null}</text>
+                            <text x={width - 70} y={20} fontSize={25} textAnchor="end">{keySignatureDisplayed}</text>
+
+                            <text x={70} y={titleRowHeight - 10} fontSize={25} textAnchor="start">{creditsDisplay[0]}</text>
+                            <text x={width / 2} y={titleRowHeight - 10} fontSize={25} textAnchor="middle">{creditsDisplay[1]}</text>
+                            <text x={width - 70} y={titleRowHeight - 10} fontSize={25} textAnchor="end">{creditsDisplay[2]}</text>
                         </svg>
+
+
                     </div>
                 </div>
                 {svgRows}

--- a/client/src/contexts/Preferences.tsx
+++ b/client/src/contexts/Preferences.tsx
@@ -21,8 +21,14 @@ export type scalePreferenceOption = (typeof scalePreferenceOptions)[number];
 export const spacingPreferenceOptions = ['narrow', 'moderate', 'wide'] as const;
 export type spacingPreferenceOption = (typeof spacingPreferenceOptions)[number];
 
-export const noteHeadPreferenceOptions = ["●", "◼", "▲", "▼", "○", "☐", "△", "▽", "⊗", "⊠"] as const; // Previous symbols: ⨂, □
-export type noteHeadPreferenceOption = (typeof noteHeadPreferenceOptions)[number];
+export const naturalNoteHeadPreferenceOptions = ["●", "○"] as const; 
+export type naturalNoteHeadPreferenceOption = (typeof naturalNoteHeadPreferenceOptions)[number];
+
+export const sharpNoteHeadPreferenceOptions = ["▲", "△", "#"] as const;
+export type sharpNoteHeadPreferenceOption = (typeof sharpNoteHeadPreferenceOptions)[number];
+
+export const flatNoteHeadPreferenceOptions = ["▼", "▽", "b"] as const; 
+export type flatNoteHeadPreferenceOption = (typeof flatNoteHeadPreferenceOptions)[number];
 
 export const clefPreferenceOptions = ["WYSIWYP","Traditional"] as const;
 export type clefPreferenceOptions = (typeof clefPreferenceOptions)[number];
@@ -33,6 +39,9 @@ export type measuresPerRowOption = (typeof measuresPerRowOptions)[number];
 export const accidentalTypeOptions = ['auto', 'sharps', 'flats'] as const;
 export type accidentalTypeOption = (typeof accidentalTypeOptions)[number];
 
+export const lyricsFontSizeOptions = ['small', 'medium', 'large'] as const;
+export type lyricsFontSizeOption = (typeof lyricsFontSizeOptions)[number];
+
 export type state = {
     noteDurationColor: colorPreferenceOption;
     noteSymbolColor: colorPreferenceOption;
@@ -40,12 +49,13 @@ export type state = {
     horizontalSpacing: spacingPreferenceOption;
     verticalSpacing: spacingPreferenceOption;
     noteScale: scalePreferenceOption;
-    naturalNoteShape: noteHeadPreferenceOption,
-    sharpNoteShape: noteHeadPreferenceOption;
-    flatNoteShape: noteHeadPreferenceOption;
+    naturalNoteShape: naturalNoteHeadPreferenceOption,
+    sharpNoteShape: sharpNoteHeadPreferenceOption;
+    flatNoteShape: flatNoteHeadPreferenceOption;
     clefSymbols: clefPreferenceOptions;
     measuresPerRow: measuresPerRowOption;
-    accidentalType: accidentalTypeOption
+    accidentalType: accidentalTypeOption;
+    lyricsFontSize: lyricsFontSizeOption
 };
 export type action = {
     type: "set";
@@ -64,7 +74,8 @@ let initialState: state = {
     flatNoteShape: '▼',
     clefSymbols: 'WYSIWYP',
     measuresPerRow: 4,
-    accidentalType: 'auto'
+    accidentalType: 'auto',
+    lyricsFontSize: 'small'
 };
 
 export const PreferencesContext = createContext(undefined! as [

--- a/client/src/contexts/Preferences.tsx
+++ b/client/src/contexts/Preferences.tsx
@@ -30,7 +30,7 @@ export type clefPreferenceOptions = (typeof clefPreferenceOptions)[number];
 export const measuresPerRowOptions = [1, 2, 3, 4, 5, 6] as const; // TODO: Consider using a slider
 export type measuresPerRowOption = (typeof measuresPerRowOptions)[number];
 
-export const accidentalTypeOptions = ['auto', 'sharp', 'flat'] as const;
+export const accidentalTypeOptions = ['auto', 'sharps', 'flats'] as const;
 export type accidentalTypeOption = (typeof accidentalTypeOptions)[number];
 
 export type state = {

--- a/client/src/pages/Convert.tsx
+++ b/client/src/pages/Convert.tsx
@@ -207,7 +207,7 @@ const Convert: React.FC<Props> = () => {
                     </div>
                 </>}
                 <div id="close" style={styles.sideBarTopOptions} onClick={() => {setShow(false);}}>
-                    Close ✕
+                    ✕
                 </div>
             </div>
 
@@ -220,6 +220,13 @@ const Convert: React.FC<Props> = () => {
                         </div>
 
                     </Expandable>
+                                      
+                    
+                        
+                        _________________________________________________
+                      Changes are made to the converted WYSIWYP file. To save in MusicXML format, select Export after editing. 
+                    
+
                 </Fragment>:<Fragment key="preferences">
 
                     <Expandable title="Staff Appearance">
@@ -268,7 +275,7 @@ const Convert: React.FC<Props> = () => {
                     <Expandable title="Note Appearance">
 
                         <div style={styles.line}>
-                            <div style={styles.name}>Accidental Type</div>
+                            <div style={styles.name}>Accidental Display</div>
                             <select value={preferences.accidentalType} onChange={
                                 (e) => {setPreferences({type: 'set', val: {accidentalType: e.target.value as any}});}
                             }>{accidentalTypeOptions.map(x => <option key={x}>{x}</option>)}</select>

--- a/client/src/pages/Convert.tsx
+++ b/client/src/pages/Convert.tsx
@@ -7,8 +7,9 @@ import {saveAs} from 'file-saver';
 import {useCurrentFileState} from '../contexts/CurrentFile';
 import MusicXML from 'musicxml-interfaces';
 import {
-    usePreferencesState, colorPreferenceOptions, scalePreferenceOptions,
-    spacingPreferenceOptions, noteHeadPreferenceOptions, measuresPerRowOptions, accidentalTypeOptions, clefPreferenceOptions
+    usePreferencesState, scalePreferenceOptions,
+    spacingPreferenceOptions, naturalNoteHeadPreferenceOptions, sharpNoteHeadPreferenceOptions, flatNoteHeadPreferenceOptions, measuresPerRowOptions,
+    accidentalTypeOptions, clefPreferenceOptions, lyricsFontSizeOptions
 } from '../contexts/Preferences';
 import jsPDF from 'jspdf';
 import canvg from 'canvg';
@@ -224,7 +225,7 @@ const Convert: React.FC<Props> = () => {
                     
                         
                         _________________________________________________
-                      Changes are made to the converted WYSIWYP file. To save in MusicXML format, select Export after editing. 
+                      Changes are made to the converted music file. To save in MusicXML format, select Export after editing. 
                     
 
                 </Fragment>:<Fragment key="preferences">
@@ -268,7 +269,15 @@ const Convert: React.FC<Props> = () => {
                             <select value={preferences.verticalSpacing} onChange={
                                 (e) => {setPreferences({type: 'set', val: {verticalSpacing: e.target.value as any}});}
                             }>{spacingPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
+                         </div>
+
+                         <div style={styles.line}>
+                             <div style={styles.name}>Lyrics Font Size</div>
+                             {/* deleted value and onchange */}
+                             <select value={preferences.lyricsFontSize} onChange={
+                                 (e) => { setPreferences({ type: 'set', val: { lyricsFontSize: e.target.value as any } }); }
+                             }>{lyricsFontSizeOptions.map(x => <option key={x}>{x}</option>)}</select>
+                         </div>
 
                     </Expandable>
 
@@ -294,7 +303,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.naturalNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {naturalNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{naturalNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                         <div style={styles.line}>
@@ -302,7 +311,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.sharpNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {sharpNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{sharpNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                         <div style={styles.line}>
@@ -310,21 +319,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.flatNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {flatNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
-
-                        <div style={styles.line}>
-                            <div style={styles.name}>Notehead Color</div>
-                            <select value={preferences.noteSymbolColor} onChange={
-                                (e) => {setPreferences({type: 'set', val: {noteSymbolColor: e.target.value as any}});}
-                            }>{colorPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
-
-                        <div style={styles.line}>
-                            <div style={styles.name}>Duration Color</div>
-                            <select value={preferences.noteDurationColor} onChange={
-                                (e) => {setPreferences({type: 'set', val: {noteDurationColor: e.target.value as any}});}
-                            }>{colorPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{flatNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                     </Expandable>

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -42,7 +42,7 @@ const Menu: React.FC<Props> = () => {
      };
 
     let deleteAllPrompt = () => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all WYSIWYP files?', 'Cancel', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all converted files?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             recentFiles.forEach(x=>{
@@ -54,7 +54,7 @@ const Menu: React.FC<Props> = () => {
         }));
     };
     let deleteSinglePrompt = (x: recentFile) => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this WYSIWYP file?', 'Cancel', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this converted file?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             let newRecentFiles = recentFiles.filter(y => y.id !== x.id);
@@ -302,7 +302,7 @@ const Menu: React.FC<Props> = () => {
                     <div style={{ ...styles.item, flex: '.35 0 auto' }} />
                 </> : <>
                         <div style={{ ...styles.item, flex: '.36 0 auto' }} />
-                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>WYSIWYP format files already converted from MusicXML</div>
+                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>files already converted from MusicXML</div>
                         <div style={{ ...styles.item, flex: '.08 0 auto' }} />
                         <div style={{ ...styles.item, ...styles.recentFiles }}>
                             <div style={{ ...styles.recentFilesInner }}>
@@ -327,10 +327,8 @@ const Menu: React.FC<Props> = () => {
                         <div style={{ ...styles.item, flex: '.24 0 auto' }} />
                     </>}
                 <div style={styles.item}>
-                    <span id="button-upload" style={styles.link}>
-                        <img src={svg} style={styles.icon} alt="" />
-                        Convert a MusicXML File
-                        <input style={styles.fileInput} type="file" title="Convert a MusicXML file" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
+                    <span id="button-upload" style={styles.link}>                        Convert another MusicXML File
+                        <input style={styles.fileInput} type="file" title="Convert another MusicXML file" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
                     </span>
                 </div>
                 {installHandle===undefined?null:<>
@@ -383,7 +381,7 @@ const styleMap = {
         width: '340px',
         height: '100%',
         cursor: 'pointer',
-        opacity: 0,
+        opacity: 0
     },
     recentFiles: {
         color: '#31B7D6',

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -36,13 +36,13 @@ const Menu: React.FC<Props> = () => {
     let [, setCurrentFile] = useCurrentFileState();
 
     let showError = (error: string) => {
-        setDialogState(Dialog.showMessage('An Error Occurred', error, 'Close', () => {
+        setDialogState(Dialog.showMessage('An Error Occurred', error, 'Cancel', () => {
             setDialogState(Dialog.close());
         }));
      };
 
     let deleteAllPrompt = () => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all files?', 'Close', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all WYSIWYP files?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             recentFiles.forEach(x=>{
@@ -54,7 +54,7 @@ const Menu: React.FC<Props> = () => {
         }));
     };
     let deleteSinglePrompt = (x: recentFile) => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this file?', 'Close', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this WYSIWYP file?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             let newRecentFiles = recentFiles.filter(y => y.id !== x.id);
@@ -289,8 +289,8 @@ const Menu: React.FC<Props> = () => {
     return (
         <Frame header="SNapp -&nbsp;Simplified&nbsp;Notation&nbsp;App&nbsp;for&nbsp;Sheet&nbsp;Music">
             {recentFiles === undefined ? null : <div style={styles.container}>
-                <div style={{ ...styles.item, flex: '1 0 auto' }} />
-                <div style={{ ...styles.item, maxWidth: '750px' }}>
+                <div style={{ ...styles.item, flex: '.37 0 auto' }} />
+                <div style={{ ...styles.item, maxWidth: '1200px' }}>
                     SNapp implements a simple and intuitive music notation known as What You See Is What You Play,
                     or WYSIWYP. With it, musicians can spend less time learning to read music and more time playing it!
                 </div>
@@ -302,7 +302,7 @@ const Menu: React.FC<Props> = () => {
                     <div style={{ ...styles.item, flex: '.35 0 auto' }} />
                 </> : <>
                         <div style={{ ...styles.item, flex: '.36 0 auto' }} />
-                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>Recent Files</div>
+                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>WYSIWYP format files already converted from MusicXML</div>
                         <div style={{ ...styles.item, flex: '.08 0 auto' }} />
                         <div style={{ ...styles.item, ...styles.recentFiles }}>
                             <div style={{ ...styles.recentFilesInner }}>
@@ -329,8 +329,8 @@ const Menu: React.FC<Props> = () => {
                 <div style={styles.item}>
                     <span id="button-upload" style={styles.link}>
                         <img src={svg} style={styles.icon} alt="" />
-                        Open MusicXML File
-                        <input style={styles.fileInput} type="file" title="Click to upload" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
+                        Convert a MusicXML File
+                        <input style={styles.fileInput} type="file" title="Convert a MusicXML file" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
                     </span>
                 </div>
                 {installHandle===undefined?null:<>
@@ -370,7 +370,7 @@ const styleMap = {
         left: 'auto',
         height: 'auto',
         marginLeft: '50%',
-        width: '70%',
+        width: '80%',
         transform: 'translate(-50%,0px)',
         textAlign: 'center',
         fontSize: '21px',
@@ -387,8 +387,8 @@ const styleMap = {
     },
     recentFiles: {
         color: '#31B7D6',
-        maxWidth: '750px',
-        height: '250px',
+        maxWidth: '1200px',
+        height: '400px',
         borderRadius: '10px',
         border: '2px solid #BBBBBB',
         padding: '5px',
@@ -404,11 +404,11 @@ const styleMap = {
     recentFilesItem: {
         display: 'flex',
         width: 'calc(100% - 10px)',
-        marginTop: '20px',
+        marginTop: '1px',
         marginLeft: '5px',
         marginRight: '5px',
         lineHeight: '40px',
-        fontSize: '24px',
+        fontSize: '22px',
         position: 'relative',
         height: '40px',
         whiteSpace: 'nowrap',

--- a/client/src/parser/MusicXML.tsx
+++ b/client/src/parser/MusicXML.tsx
@@ -219,7 +219,8 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
                             try {
                                 part.keySignatures.push({
                                     measure: measureNumber,
-                                    fifths: entry.keySignatures[0].fifths
+                                    fifths: entry.keySignatures[0].fifths,
+                                    mode: entry.keySignatures[0].mode
                                 });
                             } catch (e) {
                                 console.error('Failed to parse key signature', entry.keySignatures[0]);
@@ -315,7 +316,7 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
     // handle unprovided signatures
     tracks.forEach(track => {
         // add default values for key signatures if it is not provided.
-        if (track.keySignatures.length === 0) track.keySignatures.push({measure: 0, fifths: 0});
+        if (track.keySignatures.length === 0) track.keySignatures.push({measure: 0, fifths: 0, mode: ''});
 
         if (track.timeSignatures.length === 0) {
             if (track.measures.length === 1) {

--- a/client/src/parser/Types.tsx
+++ b/client/src/parser/Types.tsx
@@ -54,7 +54,8 @@ export type TimeSignature = {
 
 export type KeySignature = {
     measure: number,
-    fifths: number
+    fifths: number,
+    mode: any
 };
 
 // Tracks and scores


### PR DESCRIPTION
Summary of Changes
Change various text strings:
     on Convert Page:
           change "Accidental type" to "Accidental display"
            change names of choices for accidentals to "sharps" and "flats" (add s)
            on Preferences, change "Close" to "X"
            add text to Edit side menu advising of Export
        on Main Page:
              change "Close" to "Cancel" on popups
              change "Recent files" to "Files already converted from MusicXML"
              change "upload Music XML file" to "Convert another MusicXML file" and remove icon
              change file list deletion messages to "Are you sure ... converted file"
              adjust the overall display of elements:
                    reduce space between header and text
                     widen the text
                     widen the file list
                     increase the height of the file list
                     reduce the height and font size of each file list entry
Functional changes
     Disable the note color preference by removing from side bar
     Create separate lists of noteheads for naturals, flats, and sharps
     Add new noteheads in traditional format for sharps (#) and flats (b)
     Change Accidental "auto" function to choose sharps or flats based on key signature
     Change the Title area to
            include the key signature
             show the first three credits in the MusicXML file (which may include the title)
        Add a new Staff Preference to select the font size for lyrics  