### PR TITLE
small changes to prefs and KS display

### DIFF
--- a/client/src/components/SNView.tsx
+++ b/client/src/components/SNView.tsx
@@ -140,11 +140,11 @@ const SNView: React.FC<Props> = ({ xml, forcedWidth, editMode = '', editCallback
             accidentalType
         } = preferences;
 
-        // Map preference strings to numeric values
+        // Map preference strings to numeric values     2021 06 10 - change from 15, 20, 25
         let noteScaleMap: Record<scalePreferenceOption, number> = {
-            small: 15,
-            medium: 20,
-            large: 25
+            small: 9,
+            medium: 15,
+            large: 22
         };
         let staffScaleMap: Record<scalePreferenceOption, number> = {
             small: 18,
@@ -253,16 +253,14 @@ const SNView: React.FC<Props> = ({ xml, forcedWidth, editMode = '', editCallback
         let numberOfCredits = findCredits();
         console.log(creditsDisplay, numberOfCredits);
 
-        // get key signature
+        // get key signature    2021 06 10 - if no mode specified then display KS as  N Major / m minor
         let keyFifths = score.tracks[0].keySignatures[0].fifths;
         // The values for fifths range from -7 for Cb Major to +7 for C# Major.  So adjust index to names array by 7 to start at array offset 0
-        let keySignatureDisplayed = keySignatureNamesArrayMajor[keyFifths + 7] + "*";  // if no mode, default to major and indicate that with an asterisk
+        let keySignatureDisplayed = keySignatureNamesArrayMajor[keyFifths + 7] || " /" || keySignatureNamesArrayMinor[keyFifths - 7];  // if no mode, default to major / minor
         let scoreMode: any = score.tracks[0].keySignatures[0].mode;
         if (scoreMode === 'major') keySignatureDisplayed = keySignatureNamesArrayMajor[keyFifths + 7];
         else if (scoreMode === 'minor') keySignatureDisplayed = keySignatureNamesArrayMinor[keyFifths + 7];
-        else if (title !== 'no title specified')
-            if (title.includes(' minor') || title.includes(' Minor') || title.includes(' MINOR'))
-                keySignatureDisplayed = keySignatureNamesArrayMinor[keyFifths + 7] + "*";  // if no mode specified and "minor" is in the title, assume minor mode
+        
 
         let minNote: Record<StaffType, number> = {
             treble: 128,

--- a/client/src/contexts/Preferences.tsx
+++ b/client/src/contexts/Preferences.tsx
@@ -33,7 +33,7 @@ export type flatNoteHeadPreferenceOption = (typeof flatNoteHeadPreferenceOptions
 export const clefPreferenceOptions = ["WYSIWYP","Traditional"] as const;
 export type clefPreferenceOptions = (typeof clefPreferenceOptions)[number];
 
-export const measuresPerRowOptions = [1, 2, 3, 4, 5, 6] as const; // TODO: Consider using a slider
+export const measuresPerRowOptions = [1, 2, 3, 4, 5, 6, 7, 8] as const; // 2020 06 10 - increase through 8
 export type measuresPerRowOption = (typeof measuresPerRowOptions)[number];
 
 export const accidentalTypeOptions = ['auto', 'sharps', 'flats'] as const;
@@ -62,18 +62,18 @@ export type action = {
     val: Partial<state>;
 };
 
-let initialState: state = {
+let initialState: state = {  // 2021 06 10 - change defaults for horizontal and vertical spacing, measures per row
     noteDurationColor: "grey",
     noteSymbolColor: "black",
     staffScale: 'medium',
-    horizontalSpacing: 'moderate',
-    verticalSpacing: 'moderate',
+    horizontalSpacing: 'narrow',
+    verticalSpacing: 'narrow',
     noteScale: 'medium',
     naturalNoteShape: '●',
     sharpNoteShape: '▲',
     flatNoteShape: '▼',
     clefSymbols: 'WYSIWYP',
-    measuresPerRow: 4,
+    measuresPerRow: 6,
     accidentalType: 'auto',
     lyricsFontSize: 'small'
 };


### PR DESCRIPTION
Increase number of measures per row to 8, make notehead sizes smaller, change User Preferences defaults, change logic for Key Signature display